### PR TITLE
Position fixes

### DIFF
--- a/jquery.date_input.js
+++ b/jquery.date_input.js
@@ -216,10 +216,10 @@ DateInput.prototype = {
   },
   
   setPosition: function() {
-    var offset = this.input.offset();
+    var position = this.input.position();
     this.rootLayers.css({
-      top: offset.top + this.input.outerHeight(),
-      left: offset.left
+      top: position.top + this.input.outerHeight(),
+      left: position.left
     });
     
     if (this.ieframe) {

--- a/jquery.date_input.js
+++ b/jquery.date_input.js
@@ -156,7 +156,7 @@ DateInput.prototype = {
   
   // Returns true if the given event occurred inside the date selector
   insideSelector: function(event) {
-    var offset = this.dateSelector.position();
+    var offset = this.dateSelector.offset();
     offset.right = offset.left + this.dateSelector.outerWidth();
     offset.bottom = offset.top + this.dateSelector.outerHeight();
     


### PR DESCRIPTION
Hi!

When date input parent element is position: relative, the position and closing code uses incorrect methods to get the correct offset amounts. The positioning problem is documented in ticket #2.

I tested this in Firefox 4.0.1, Chrome 11.0.696.65 and Safari 5.0.5.

I hope you'll accept the pull request. Thanks!

Vesa Vänskä
