### PR TITLE
Added missing tilde in short month name for sábado.

### DIFF
--- a/translations/jquery.date_input.es_ES.js
+++ b/translations/jquery.date_input.es_ES.js
@@ -1,5 +1,5 @@
 jQuery.extend(DateInput.DEFAULT_OPTS, {
   month_names: ["Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"],
   short_month_names: ["Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"],
-  short_day_names: ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sab"]
+  short_day_names: ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"]
 });


### PR DESCRIPTION
If short version for "Miércoles" is "Mié", then the tilde should not be omited for "Sáb"
